### PR TITLE
Updated CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,12 @@ file(GLOB SOURCES "src/*.cpp")
 
 # Change name of executable to desired name
 add_executable(hello_world ${SOURCES})
+
+# Check if pthreads.h is being used
+find_package(Threads REQUIRED)
+if(THREADS_HAVE_PTHREAD_ARG)
+  target_compile_options(PUBLIC hello_world "-pthread")
+endif()
+if(CMAKE_THREAD_LIBS_INIT)
+  target_link_libraries(hello_world "${CMAKE_THREAD_LIBS_INIT}")
+endif()


### PR DESCRIPTION
Allows cmake to include the pthreads.h library if it is being used.
